### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dsdcapis/full-truckload-public-approvers


### PR DESCRIPTION
Creating the initial CODEOWNERS file which will require the Full Truckload Public Approvers to review for any changes.